### PR TITLE
Fix for dying on first map of a campaign

### DIFF
--- a/L4D1/L4Dv1.12_alpha.asl
+++ b/L4D1/L4Dv1.12_alpha.asl
@@ -223,7 +223,7 @@ split
 	if(settings["campaignSplit"])
 	{
 	    //Split on finales		
-		if((current.cutscenePlaying1 || current.cutscenePlaying2) && !(old.cutscenePlaying1 || old.cutscenePlaying2))
+		if(!current.gameLoading && (current.cutscenePlaying1 || current.cutscenePlaying2) && !(old.cutscenePlaying1 || old.cutscenePlaying2))
 		{
 		    print("Split on finale");
 		    return true;		    	


### PR DESCRIPTION
copied from
https://github.com/SirWillian/Autosplitters/commit/efacbca4a3f45cd131de658558393c90c8a3334a