### PR TITLE
Change autostart failsafe timer to 0.25s from 1s

### DIFF
--- a/L4D2/L4D2.asl
+++ b/L4D2/L4D2.asl
@@ -537,7 +537,7 @@ start
         // Once we have control after a cutscene plays for at least 1 second, we're ready to start.
         if (vars.hasControl.Current && !vars.gameLoading.Current)
         {
-            if (DateTime.Now - vars.cutsceneStart > TimeSpan.FromSeconds(1))
+            if (DateTime.Now - vars.cutsceneStart > TimeSpan.FromSeconds(0.25))
             {
                 print("CUSTSCENE RAN FOR " + (DateTime.Now - vars.cutsceneStart));
                 vars.cutsceneStart = DateTime.MaxValue;
@@ -618,7 +618,7 @@ split
                 // Once we have control after a cutscene plays for at least 1 second, we're ready to split
                 if (vars.hasControl.Current)
                 {
-                    if (DateTime.Now - vars.cutsceneStart > TimeSpan.FromSeconds(1))
+                    if (DateTime.Now - vars.cutsceneStart > TimeSpan.FromSeconds(0.25))
                     {
                         print("(burhacSplit) CUTSCENE RAN FOR " + (DateTime.Now - vars.cutsceneStart));
                         vars.cutsceneStart = DateTime.MaxValue;


### PR DESCRIPTION
Changing this because otherwise it's annoying that you can't timescale within a second leading up to the start of the run. 250ms seems reasonable but we can revisit this in the future if needed.