### PR TITLE
Fix for double split on broken finales

### DIFF
--- a/L4D2/L4D2.asl
+++ b/L4D2/L4D2.asl
@@ -585,6 +585,7 @@ split
     {
         if (vars.finaleTrigger.Current && !vars.finaleTrigger.Old)
         {
+            vars.delayedSplitTimer.Reset()
             if (vars.whatsLoading.Current == vars.lastSplit)
             {
                 print("Ceased double split attempt");
@@ -665,6 +666,7 @@ split
     {
         if (vars.finaleTrigger.Current && !vars.finaleTrigger.Old)
         {
+            vars.delayedSplitTimer.Reset()
             if (vars.whatsLoading.Current == vars.lastSplit)
             {
                 print("Ceased double split attempt");


### PR DESCRIPTION
we were checking for an erroneous split at the wrong time. there's probably a smarter way to go about this but this is the best I can come up with in 15 minutes